### PR TITLE
Add compact method to RocksDB::DB

### DIFF
--- a/ext/rocksdb/rocksdb_db_rb.cc
+++ b/ext/rocksdb/rocksdb_db_rb.cc
@@ -268,4 +268,26 @@ extern "C" {
   VALUE rocksdb_db_debug(VALUE self){
     return Qnil;
   }
+
+  VALUE rocksdb_db_compact(int argc, VALUE* argv, VALUE self) {
+    VALUE v_from, v_to;
+    rocksdb::Slice from, to;
+
+    rb_scan_args(argc, argv, "02", &v_from, &v_to);
+
+    if(!NIL_P(v_from)) {
+      Check_Type(v_from, T_STRING);
+      from = rocksdb::Slice((char*)RSTRING_PTR(v_from), RSTRING_LEN(v_from));
+    }
+
+    if(!NIL_P(v_to)) {
+      Check_Type(v_to, T_STRING);
+      to = rocksdb::Slice((char*)RSTRING_PTR(v_to), RSTRING_LEN(v_to));
+    }
+
+    rocksdb_pointer* db_pointer;
+    Data_Get_Struct(self, rocksdb_pointer, db_pointer);
+    rocksdb::Status status = db_pointer->db->CompactRange(rocksdb::CompactRangeOptions(), &from, &to);
+    return status.ok() ? Qtrue : Qfalse;
+  }
 }

--- a/ext/rocksdb/rocksdb_db_rb.h
+++ b/ext/rocksdb/rocksdb_db_rb.h
@@ -18,6 +18,7 @@ extern "C" {
   VALUE rocksdb_db_each_index(VALUE self);
   VALUE rocksdb_db_each_with_index(VALUE self);
   VALUE rocksdb_db_reverse_each(VALUE self);
+  VALUE rocksdb_db_compact(int argc, VALUE* argv, VALUE self);
   void db_free(rocksdb_pointer* db_pointer);
   void set_opt(rocksdb::Options* opt, VALUE *v_options);
   void set_opt_unit_val(uint64_t* opt, char* name, VALUE *v_options);

--- a/ext/rocksdb/rocksdb_rb.cc
+++ b/ext/rocksdb/rocksdb_rb.cc
@@ -30,6 +30,7 @@ extern "C" {
     rb_define_method(cRocksdb_db, "close", (METHOD)rocksdb_db_close, 0);
     rb_define_method(cRocksdb_db, "debug", (METHOD)rocksdb_db_debug, 0);
     rb_define_method(cRocksdb_db, "new_iterator", (METHOD)rocksdb_db_new_iterator, 0);
+    rb_define_method(cRocksdb_db, "compact", (METHOD)rocksdb_db_compact, -1);
 
     rb_define_method(cRocksdb_db, "iterator", (METHOD)rocksdb_db_each, 0);
     rb_define_method(cRocksdb_db, "each_index", (METHOD)rocksdb_db_each_index, 0);

--- a/spec/db_spec.rb
+++ b/spec/db_spec.rb
@@ -115,6 +115,24 @@ describe RocksDB do
     expect(@rocksdb["test:hash"]).to eq "a"
 
   end
+
+  context 'compact' do
+    it 'works with no parameters' do
+      expect(@rocksdb.compact).to eq(true)
+    end
+
+    it 'works with one parameter' do
+      expect(@rocksdb.compact('a')).to eq(true)
+    end
+
+    it 'works with two parameters' do
+      expect(@rocksdb.compact('a', 'x')).to eq(true)
+    end
+
+    it 'works with nil as first parameter' do
+      expect(@rocksdb.compact(nil, 'x')).to eq(true)
+    end
+  end
   
   after do
     @rocksdb.close


### PR DESCRIPTION
This maps to db->CompactRange function, which removes duplicates etc. for a given range of keys.