### PR TITLE
Support 'max_open_files' option

### DIFF
--- a/ext/rocksdb/rocksdb_db_rb.cc
+++ b/ext/rocksdb/rocksdb_db_rb.cc
@@ -73,6 +73,7 @@ extern "C" {
   void set_opt(rocksdb::Options* options, VALUE *v_options){
     set_opt_unit_val(&options->max_bytes_for_level_base, (char *) "max_bytes_for_level_base", v_options);
     set_opt_unit_val(&options->delete_obsolete_files_period_micros, (char *) "delete_obsolete_files_period_micros", v_options);
+    set_opt_int_val(&options->max_open_files, (char *) "max_open_files", v_options);
   }
 
   VALUE db_alloc(VALUE klass){


### PR DESCRIPTION
Greetings! Thanks for the awesome library, it works flawlessly locally!

This PR is to support and addition rocksdb option in the ruby extension. We need it as our local db is quite large and it is not feasible to open lots of files.

Thanks in advance!