### PR TITLE
Get property

### DIFF
--- a/ext/rocksdb/rocksdb_db_rb.cc
+++ b/ext/rocksdb/rocksdb_db_rb.cc
@@ -119,6 +119,23 @@ extern "C" {
     return status.ok() ? Qtrue : Qfalse;
   }
 
+  VALUE rocksdb_db_property(VALUE self, VALUE v_key){
+    Check_Type(v_key, T_STRING);
+
+    rocksdb_pointer* db_pointer;
+    Data_Get_Struct(self, rocksdb_pointer, db_pointer);
+
+    std::string key = std::string((char*)RSTRING_PTR(v_key), RSTRING_LEN(v_key));
+    std::string value;
+    if (db_pointer->db == NULL) {
+      rb_raise(rb_eRuntimeError, "db not open");
+    }
+
+    bool status = db_pointer->db->GetProperty(key, &value);
+    if(!status) return Qnil;
+    return rb_enc_str_new(value.data(), value.size(), rb_utf8_encoding());
+  }
+
   VALUE rocksdb_db_get(VALUE self, VALUE v_key){
     Check_Type(v_key, T_STRING);
 

--- a/ext/rocksdb/rocksdb_db_rb.h
+++ b/ext/rocksdb/rocksdb_db_rb.h
@@ -8,6 +8,7 @@ extern "C" {
   VALUE db_alloc(VALUE klass);
   VALUE rocksdb_db_put(VALUE self, VALUE v_key, VALUE v_value);
   VALUE rocksdb_db_write(VALUE self, VALUE v_write);
+  VALUE rocksdb_db_property(VALUE self, VALUE v_key);
   VALUE rocksdb_db_get(VALUE self, VALUE v_key);
   VALUE rocksdb_db_multi_get(VALUE self, VALUE v_array);
   VALUE rocksdb_db_delete(VALUE self, VALUE v_key);

--- a/ext/rocksdb/rocksdb_rb.cc
+++ b/ext/rocksdb/rocksdb_rb.cc
@@ -22,6 +22,7 @@ extern "C" {
 
     rb_define_private_method(cRocksdb_db, "__initialize", (METHOD)rocksdb_db_init, -1);
     rb_define_private_method(cRocksdb_db, "__initialize2", (METHOD)rocksdb_db_init2, -1);
+    rb_define_method(cRocksdb_db, "property", (METHOD)rocksdb_db_property, 1);
     rb_define_method(cRocksdb_db, "put", (METHOD)rocksdb_db_put, 2);
     rb_define_method(cRocksdb_db, "write", (METHOD)rocksdb_db_write, 1);
     rb_define_method(cRocksdb_db, "get", (METHOD)rocksdb_db_get, 1);

--- a/spec/db_spec.rb
+++ b/spec/db_spec.rb
@@ -7,6 +7,11 @@ describe RocksDB do
     @rocksdb = RocksDB::DB.new("/tmp/file")
   end
 
+  it "should get property" do
+    @rocksdb.put("test:read", "1")
+    expect(@rocksdb.property("rocksdb.estimate-num-keys")).to eq("21")
+  end
+
   it 'should get data' do
     @rocksdb.put("test:read", "1")
     expect(@rocksdb.is_readonly?).to eq false


### PR DESCRIPTION
Keeping the ball rolling with enhancements to this great lib!

This PR adds support for the 'GetProperty' method on the base rocksdb class, allowing us to get properties set on the underlying db.

Includes spec testing functionality and verified locally against a production database.