### PR TITLE
Don't overwrite readonly if other options are given in hash format.

### DIFF
--- a/lib/rocksdb.rb
+++ b/lib/rocksdb.rb
@@ -31,8 +31,6 @@ module RocksDB
       is_readonly = options[:readonly] || false
 
       if rocksdb_options.is_a? Hash
-        is_readonly = rocksdb_options.delete(:readonly)
-
         rocksdb_options = rocksdb_options.map do |key, value|
           [key, value].join("=")
         end.join(";")


### PR DESCRIPTION
Currently, the following code
```
RocksDB.open_readonly('path', keep_log_file_num: 5)
```
opens the RocksDB in read-write mode. This is because the passed options overwrite the read-only setting, even if no read-only option is present.

This PR tries to remedy that by using `||=` instead of `=` in the read-only setting assignment.

Another solution to this inconsistency could be to remove the ability to set the read-only setting in the passed options altogether, since it's not possible to do this if you pass the options as a string either.