### PR TITLE
c++17 needed for latest rocksdb on mac using brew

### DIFF
--- a/ext/rocksdb/extconf.rb
+++ b/ext/rocksdb/extconf.rb
@@ -1,12 +1,12 @@
 require "mkmf"
 
 dir_config('rocksdb')
-RbConfig::CONFIG["CPP"] = "g++ -E -std=gnu++11"
+RbConfig::CONFIG["CPP"] = "g++ -E -std=gnu++17"
 
 DEBUG_BUILD = have_library('rocksdb_debug') || ENV["DEBUG_LEVEL"]
 
 if have_header('rocksdb/db.h') and (have_library('rocksdb') or have_library('rocksdb_debug'))
-  $CPPFLAGS << " -std=gnu++11"
+  $CPPFLAGS << " -std=gnu++17"
 
   if DEBUG_BUILD
     CONFIG["optflags"] = "-O0"


### PR DESCRIPTION
Latest stable rocksdb 7.5.3 gives the following error 

```
In file included from /opt/homebrew/Cellar/rocksdb/7.5.3/include/rocksdb/write_batch_base.h:14:
/opt/homebrew/Cellar/rocksdb/7.5.3/include/rocksdb/wide_columns.h:48:20: error: no template named 'make_from_tuple' in namespace 'std'; did you mean 'make_tuple'?
      : name_(std::make_from_tuple<Slice>(std::forward<NTuple>(name_tuple))),
              ~~~~~^~~~~~~~~~~~~~~
                   make_tuple
```

make_from_tuple is indeed used from rocksdb, which is a c++17 onwards feature, updated cppflags to use `-std=gnu++17`

This resolves the above compiler error and works.