### PR TITLE
Fix build for MacOS on Ruby 3.1

### DIFF
--- a/ext/rocksdb/extconf.rb
+++ b/ext/rocksdb/extconf.rb
@@ -1,7 +1,9 @@
 require "mkmf"
 
 dir_config('rocksdb')
-RbConfig::CONFIG["CPP"] = "g++ -E -std=gnu++17"
+cxx = RbConfig::CONFIG["CXX"]
+RbConfig::CONFIG["CPP"] = "#{cxx} -E -std=gnu++17"
+RbConfig::CONFIG["CC"] = "#{cxx} -std=gnu++17"
 
 DEBUG_BUILD = have_library('rocksdb_debug') || ENV["DEBUG_LEVEL"]
 


### PR DESCRIPTION
This fixes the issue described in #32 - inability to build the gem on MacOS and Ruby 3.1. I tested it on both Intel and M1 Macs and it works.

## Details

Between Ruby 3.0 and 3.1 the behaviour of `have_library` has changed. Now it does not use `RbConfig::CONFIG['CPP']`, but `RbConfig::CONFIG['CC']`. To allow the extension to compile on MacOS, the latter needs to be adjusted as well.

This also uses `RbConfig::CONFIG['CXX']` instead of hard-coded `g++`, as using `g++` caused me some troubles with unknown flags on MacOS as well (I have `gcc` installed along clang for _reasons_).