### PR TITLE
Fix uninitialized constant Rocksdb during gem install

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
+require_relative "lib/rocksdb/ruby/version"
+
 gem_root = File.expand_path("..", __FILE__)
 librocksdb_build = File.join(gem_root, "ext", "librocksdb-build")
 librocksdb_install = File.join(gem_root, "ext", "librocksdb")


### PR DESCRIPTION
When I try to install the tip of master, it failed to build

```
Using rocksdb-ruby 1.0.2 from https://github.com/isamu/rocksdb-ruby.git (at master@7823812)
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/bing-changlai/.rvm/gems/ruby-3.2.2/bundler/gems/rocksdb-ruby-782381264ebc
/Users/bing-changlai/.rvm/rubies/ruby-3.2.2/bin/ruby -rrubygems /Users/bing-changlai/.rvm/rubies/ruby-3.2.2/lib/ruby/gems/3.2.0/gems/rake-13.0.6/exe/rake
RUBYARCHDIR\=/Users/bing-changlai/.rvm/gems/ruby-3.2.2/bundler/gems/extensions/arm64-darwin-22/3.2.0/rocksdb-ruby-782381264ebc
RUBYLIBDIR\=/Users/bing-changlai/.rvm/gems/ruby-3.2.2/bundler/gems/extensions/arm64-darwin-22/3.2.0/rocksdb-ruby-782381264ebc
rake aborted!
NameError: uninitialized constant Rocksdb
/Users/bing-changlai/.rvm/gems/ruby-3.2.2/bundler/gems/rocksdb-ruby-782381264ebc/Rakefile:44:in `block (2 levels) in <top (required)>'
/Users/bing-changlai/.rvm/gems/ruby-3.2.2/bundler/gems/rocksdb-ruby-782381264ebc/Rakefile:62:in `block (2 levels) in <top (required)>'
/Users/bing-changlai/.rvm/gems/ruby-3.2.2/bundler/gems/rocksdb-ruby-782381264ebc/Rakefile:17:in `block in <top (required)>'
Tasks: TOP => librocksdb:build => /Users/bing-changlai/.rvm/gems/ruby-3.2.2/bundler/gems/rocksdb-ruby-782381264ebc/ext/librocksdb-build
(See full trace by running task with --trace)

rake failed, exit code 1

Gem files will remain installed in /Users/bing-changlai/.rvm/gems/ruby-3.2.2/bundler/gems/rocksdb-ruby-782381264ebc for inspection.
Results logged to /Users/bing-changlai/.rvm/gems/ruby-3.2.2/bundler/gems/extensions/arm64-darwin-22/3.2.0/rocksdb-ruby-782381264ebc/gem_make.out
```

This PR is a fix for that.