### PR TITLE
chore: bump GitHub Actions to latest + Node 24

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
         - 3.2
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):


### PR DESCRIPTION
Mechanical bump of GitHub Actions to current latest and (where applicable) extend Node matrix to include 24.x. See commit message for details. Auto-generated across receptron/* + isamu/* source repos. CI on this PR is the verification.